### PR TITLE
[Proposal] Initial approach

### DIFF
--- a/src/extractError.js
+++ b/src/extractError.js
@@ -1,0 +1,44 @@
+const RequestShortener = require("webpack/lib/RequestShortener");
+const requestShortener = new RequestShortener(process.cwd());
+
+function extractError (e) {
+  return {
+    message: e.message,
+    file: getFile(e),
+    origin: getOrigin(e),
+    name: e.name,
+    severity: 0,
+    webpackError: e,
+  };
+}
+
+function getFile (e) {
+  if (e.file) {
+    return e.file;
+  } else if (e.module && e.module.readableIdentifier && typeof e.module.readableIdentifier === "function") {
+    return e.module.readableIdentifier(requestShortener);
+  }
+}
+
+function getOrigin (e) {
+  let origin = '';
+  if (e.dependencies && e.origin) {
+    origin += '\n @ ' + e.origin.readableIdentifier(requestShortener);
+    e.dependencies.forEach(function (dep) {
+      if (!dep.loc) return;
+      if (typeof dep.loc === "string") return;
+      if (!dep.loc.start) return;
+      if (!dep.loc.end) return;
+      origin += ' ' + dep.loc.start.line + ':' + dep.loc.start.column + '-' +
+        (dep.loc.start.line !== dep.loc.end.line ? dep.loc.end.line + ':' : '') + dep.loc.end.column;
+    });
+    var current = e.origin;
+    while (current.issuer) {
+      current = current.issuer;
+      origin += '\n @ ' + current.readableIdentifier(requestShortener);
+    }
+  }
+  return origin;
+}
+
+module.exports = extractError;

--- a/src/extractError.js
+++ b/src/extractError.js
@@ -33,7 +33,7 @@ function getOrigin (e) {
         (dep.loc.start.line !== dep.loc.end.line ? dep.loc.end.line + ':' : '') + dep.loc.end.column;
     });
     var current = e.origin;
-    while (current.issuer) {
+    while (current.issuer && typeof current.issuer.readableIdentifier === 'function') {
       current = current.issuer;
       origin += '\n @ ' + current.readableIdentifier(requestShortener);
     }

--- a/src/formatErrors.js
+++ b/src/formatErrors.js
@@ -1,0 +1,11 @@
+function formatErrors(errors, formatters, errorType) {
+  return formatters.reduce((output, formatter) => {
+    if (!output) {
+      return formatter(errors, errorType);
+    }
+
+    return output;
+  }, null);
+}
+
+module.exports = formatErrors;

--- a/src/formatErrors.js
+++ b/src/formatErrors.js
@@ -1,9 +1,8 @@
 function formatErrors(errors, formatters, errorType) {
-  const formatted = formatters.reduce((output, formatter) => (
-    output.concat(formatter(errors, errorType) || [])
-  ), []);
+  const format = (formatter) => formatter(errors, errorType) || [];
+  const flatten = (accum, curr) => accum.concat(curr);
 
-  return formatted;
+  return formatters.map(format).reduce(flatten, [])
 }
 
 module.exports = formatErrors;

--- a/src/formatErrors.js
+++ b/src/formatErrors.js
@@ -1,11 +1,9 @@
 function formatErrors(errors, formatters, errorType) {
-  return formatters.reduce((output, formatter) => {
-    if (!output) {
-      return formatter(errors, errorType);
-    }
+  const formatted = formatters.reduce((output, formatter) => (
+    output.concat(formatter(errors, errorType) || [])
+  ), []);
 
-    return output;
-  }, null);
+  return formatted;
 }
 
 module.exports = formatErrors;

--- a/src/formatters/defaultError.js
+++ b/src/formatters/defaultError.js
@@ -1,19 +1,15 @@
 const chalk = require('chalk');
 
-function displayError(index, severity, error) {
-  const displayError = []
-  if (error.file) {
-    displayError.push(chalk.red((index + 1) + ') ' + severity) + ' in ' + error.file);
-  } else {
-    displayError.push(chalk.red((index + 1) + ') ' + severity));
-  }
-  displayError.push('');
-  displayError.push(error.message);
-  if (error.origin) {
-    displayError.push(error.origin);
-  }
-  displayError.push('');
-  return displayError;
+function displayError(index, severity, { file, message, origin }) {
+  const baseError = chalk.red(`${index + 1}) ${severity}`);
+
+  return [
+    `${baseError} ${file ? 'in ' + file : ''}`,
+    '',
+    message,
+    (origin ? origin : undefined),
+    ''
+  ].filter((chunk) => chunk !== undefined);
 }
 
 function isDefaultError(error) {

--- a/src/formatters/defaultError.js
+++ b/src/formatters/defaultError.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
 
-function displayError (index, severity, error) {
+function displayError(index, severity, error) {
   const displayError = []
   if (error.file) {
     displayError.push(chalk.red((index + 1) + ') ' + severity) + ' in ' + error.file);
@@ -16,16 +16,16 @@ function displayError (index, severity, error) {
   return displayError;
 }
 
-function isGenericError(error) {
+function isDefaultError(error) {
   return !error.type || error.type === 'babel-syntax-error';
 }
 
-module.exports = {
-  format: (errors, type) => {
-    return errors
-      .filter(isGenericError)
-      .reduce((accum, error, i ) => (
-        accum.concat(displayError(i, type, error))
-      ), []);
-  },
-};
+function format(errors, type) {
+  return errors
+    .filter(isDefaultError)
+    .reduce((accum, error, i ) => (
+      accum.concat(displayError(i, type, error))
+    ), []);
+}
+
+module.exports = format;

--- a/src/formatters/moduleNotFound.js
+++ b/src/formatters/moduleNotFound.js
@@ -1,14 +1,31 @@
+function dependenciesNotFound(count) {
+  if (count === 1) {
+    return 'This dependency was not found in node_modules:';
+  }
+
+  return 'These dependencies were not found in node_modules:';
+}
+
+function forgetToInstall(count) {
+  if (count === 1) {
+    return 'Did you forget to run npm install --save for it?';
+  }
+
+  return 'Did you forget to run npm install --save for them?';
+}
+
 function formatErrors(errors) {
   if (errors.length === 0) {
-    return;
+    return [];
   }
-  const displayError = [];
-  displayError.push('These dependencies were not found in node_modules:');
-  displayError.push('');
-  errors.forEach((error, index) => displayError.push(`* ${error.module}`));
-  displayError.push('');
-  displayError.push('Did you forget to run npm install --save for them?')
-  return displayError;
+
+  return [
+    dependenciesNotFound(errors.length),
+    '',
+    ...errors.map(({ module }) =>`* ${module}`),
+    '',
+    forgetToInstall(errors.length),
+  ];
 }
 
 function format(errors) {

--- a/src/formatters/moduleNotFound.js
+++ b/src/formatters/moduleNotFound.js
@@ -1,0 +1,20 @@
+function formatErrors(errors) {
+  if (errors.length === 0) {
+    return;
+  }
+  const displayError = [];
+  displayError.push('These dependencies were not found in node_modules:');
+  displayError.push('');
+  errors.forEach((error, index) => displayError.push(`* ${error.module}`));
+  displayError.push('');
+  displayError.push('Did you forget to run npm install --save for them?')
+  return displayError;
+}
+
+function format(errors) {
+  return formatErrors(errors.filter((e) => (
+    e.type === 'module-not-found'
+  )));
+}
+
+module.exports = format;

--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -6,13 +6,13 @@ const formatErrors = require('./formatErrors');
 const debug = require('./debug');
 
 const transformers = [
-  require('./transformers/babelSyntax').transform,
-  require('./transformers/moduleNotFound').transform,
+  require('./transformers/babelSyntax'),
+  require('./transformers/moduleNotFound'),
 ];
 
 const formatters = [
-  require('./transformers/moduleNotFound').format,
-  require('./transformers/genericError').format,
+  require('./formatters/moduleNotFound'),
+  require('./formatters/defaultError'),
 ];
 
 function safeRequire (moduleName) {

--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const chalk = require('chalk');
 const os = require('os');
-const processError = require('./processError');
+const processErrors = require('./processError');
 const debug = require('./debug');
 
 const transformers = [
@@ -56,10 +56,7 @@ class FriendlyErrorsWebpackPlugin {
       }
 
       if (hasErrors) {
-        let processedErrors = stats.compilation.errors.map((error) => {
-          return processError(error, transformers);
-        });
-
+        let processedErrors = processErrors(stats.compilation.errors, transformers);
         const nbErrors = processedErrors.length;
         displayCompilationMessage(`Failed to compile with ${nbErrors} errors`, 'red');
 
@@ -81,9 +78,7 @@ class FriendlyErrorsWebpackPlugin {
       }
 
       if (hasWarnings) {
-        const processedWarns = stats.compilation.warnings.map((error) => {
-          return processError(error, transformers);
-        });
+        const processedWarns = processErrors(stats.compilation.warnings, transformers);
         const nbWarning = processedWarns.length;
         displayCompilationMessage(`Compiled with ${nbWarning} warnings`, 'yellow');
 

--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -2,6 +2,7 @@ const path = require('path');
 const chalk = require('chalk');
 const os = require('os');
 const processErrors = require('./processError');
+const formatErrors = require('./formatErrors');
 const debug = require('./debug');
 
 const transformers = [
@@ -65,14 +66,7 @@ class FriendlyErrorsWebpackPlugin {
         }
 
         processedErrors = getMaxSeverityErrors(processedErrors, 'severity');
-        let formattedErrors = formatters.reduce((output, formatter) => {
-          if (!output) {
-            return formatter(processedErrors, 'Error');
-          }
-
-          return output;
-        }, null);
-
+        let formattedErrors = formatErrors(processedErrors, formatters, 'Error');
         formattedErrors.map((errorSection) => debug.log(errorSection));
         return;
       }
@@ -82,13 +76,7 @@ class FriendlyErrorsWebpackPlugin {
         const nbWarning = processedWarns.length;
         displayCompilationMessage(`Compiled with ${nbWarning} warnings`, 'yellow');
 
-        let formattedWarning = formatters.reduce((output, formatter) => {
-          if (!output) {
-            return formatter(processedWarns, 'Warning');
-          }
-
-          return output;
-        }, null);
+        let formattedWarning = formatErrors(processedWarns, formatters, 'Warning');
 
         formattedWarning.map((errorSection) => debug.log(errorSection));
       }

--- a/src/processError.js
+++ b/src/processError.js
@@ -26,7 +26,6 @@ function extractError (e) {
   };
 }
 
-
 function getFile (e) {
   if (e.file) {
     return e.file;

--- a/src/processError.js
+++ b/src/processError.js
@@ -2,11 +2,12 @@ const RequestShortener = require("webpack/lib/RequestShortener");
 const requestShortener = new RequestShortener(process.cwd());
 
 function processErrors(errors, transformers) {
+  const transform = (error, transformer) => transformer(error);
+  const applyTransformations = (error) => transformers.reduce(transform, error);
+
   return errors
     .map(extractError)
-    .map((error) => (
-      transformers.reduce((e, t) => t(e), error)
-    ));
+    .map(applyTransformations);
 }
 
 function extractError (e) {

--- a/src/processError.js
+++ b/src/processError.js
@@ -5,9 +5,7 @@ function processErrors(errors, transformers) {
   return errors
     .map(extractError)
     .map((error) => (
-      transformers.reduce((e, t) => (
-        t(e)
-      ), error)
+      transformers.reduce((e, t) => t(e), error)
     ));
 }
 

--- a/src/processError.js
+++ b/src/processError.js
@@ -1,53 +1,10 @@
-const RequestShortener = require("webpack/lib/RequestShortener");
-const requestShortener = new RequestShortener(process.cwd());
+const extractError = require('./extractError');
 
 function processErrors(errors, transformers) {
   const transform = (error, transformer) => transformer(error);
   const applyTransformations = (error) => transformers.reduce(transform, error);
 
-  return errors
-    .map(extractError)
-    .map(applyTransformations);
-}
-
-function extractError (e) {
-  return {
-    message: e.message,
-    file: getFile(e),
-    origin: getOrigin(e),
-    name: e.name,
-    severity: 0,
-    webpackError: e,
-  };
-}
-
-function getFile (e) {
-  if (e.file) {
-    return e.file;
-  } else if (e.module && e.module.readableIdentifier && typeof e.module.readableIdentifier === "function") {
-    return e.module.readableIdentifier(requestShortener);
-  }
-}
-
-function getOrigin (e) {
-  let origin = '';
-  if (e.dependencies && e.origin) {
-    origin += '\n @ ' + e.origin.readableIdentifier(requestShortener);
-    e.dependencies.forEach(function (dep) {
-      if (!dep.loc) return;
-      if (typeof dep.loc === "string") return;
-      if (!dep.loc.start) return;
-      if (!dep.loc.end) return;
-      origin += ' ' + dep.loc.start.line + ':' + dep.loc.start.column + '-' +
-        (dep.loc.start.line !== dep.loc.end.line ? dep.loc.end.line + ':' : '') + dep.loc.end.column;
-    });
-    var current = e.origin;
-    while (current.issuer) {
-      current = current.issuer;
-      origin += '\n @ ' + current.readableIdentifier(requestShortener);
-    }
-  }
-  return origin;
+  return errors.map(extractError).map(applyTransformations);
 }
 
 module.exports = processErrors;

--- a/src/processError.js
+++ b/src/processError.js
@@ -1,10 +1,18 @@
 const RequestShortener = require("webpack/lib/RequestShortener");
 const requestShortener = new RequestShortener(process.cwd());
 
-function processError(webpackError, transformers) {
-  return transformers.reduce((error, transformer) => {
-    return transformer(error);
-  }, extractError(webpackError));
+function applyFirst(collection, cb) {
+
+}
+
+function processErrors(errors, transformers) {
+  return errors
+    .map(extractError)
+    .map((error) => (
+      transformers.reduce((e, t) => (
+        t(e)
+      ), error)
+    ));
 }
 
 function extractError (e) {
@@ -48,4 +56,4 @@ function getOrigin (e) {
   return origin;
 }
 
-module.exports = processError;
+module.exports = processErrors;

--- a/src/processError.js
+++ b/src/processError.js
@@ -1,10 +1,6 @@
 const RequestShortener = require("webpack/lib/RequestShortener");
 const requestShortener = new RequestShortener(process.cwd());
 
-function applyFirst(collection, cb) {
-
-}
-
 function processErrors(errors, transformers) {
   return errors
     .map(extractError)

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -1,26 +1,26 @@
 const TYPE = 'babel-syntax-error';
 
-function cleanStackTrace (message) {
+function cleanStackTrace(message) {
   return message
     .replace(/^\s*at\s.*:\d+:\d+[\s\)]*\n/gm, ''); // at ... ...:x:y
 }
 
-function isBabelSyntaxError (e) {
+function isBabelSyntaxError(e) {
   return e.type === TYPE ||
     e.name === 'ModuleBuildError' &&
     e.message.indexOf('SyntaxError') >= 0;
 }
 
-module.exports = {
-  transform: (error) => {
-    if (isBabelSyntaxError(error)) {
-      return Object.assign({}, error, {
-        message: cleanStackTrace(error.message + '\n'),
-        type: TYPE,
-        severity: 1000,
-      });
-    }
+function transform(error) {
+  if (isBabelSyntaxError(error)) {
+    return Object.assign({}, error, {
+      message: cleanStackTrace(error.message + '\n'),
+      type: TYPE,
+      severity: 1000,
+    });
+  }
 
-    return error;
-  },
-};
+  return error;
+}
+
+module.exports = transform;

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -1,0 +1,26 @@
+const TYPE = 'babel-syntax-error';
+
+function cleanStackTrace (message) {
+  return message
+    .replace(/^\s*at\s.*:\d+:\d+[\s\)]*\n/gm, ''); // at ... ...:x:y
+}
+
+function isBabelSyntaxError (e) {
+  return e.type === TYPE ||
+    e.name === 'ModuleBuildError' &&
+    e.message.indexOf('SyntaxError') >= 0;
+}
+
+module.exports = {
+  transform: (error) => {
+    if (isBabelSyntaxError(error)) {
+      return Object.assign({}, error, {
+        message: cleanStackTrace(error.message + '\n'),
+        type: TYPE,
+        severity: 1000,
+      });
+    }
+
+    return error;
+  },
+};

--- a/src/transformers/genericError.js
+++ b/src/transformers/genericError.js
@@ -1,0 +1,31 @@
+const chalk = require('chalk');
+
+function displayError (index, severity, error) {
+  const displayError = []
+  if (error.file) {
+    displayError.push(chalk.red((index + 1) + ') ' + severity) + ' in ' + error.file);
+  } else {
+    displayError.push(chalk.red((index + 1) + ') ' + severity));
+  }
+  displayError.push('');
+  displayError.push(error.message);
+  if (error.origin) {
+    displayError.push(error.origin);
+  }
+  displayError.push('');
+  return displayError;
+}
+
+function isGenericError(error) {
+  return !error.type || error.type === 'babel-syntax-error';
+}
+
+module.exports = {
+  format: (errors, type) => {
+    return errors
+      .filter(isGenericError)
+      .reduce((accum, error, i ) => (
+        accum.concat(displayError(i, type, error))
+      ), []);
+  },
+};

--- a/src/transformers/moduleNotFound.js
+++ b/src/transformers/moduleNotFound.js
@@ -1,0 +1,44 @@
+const TYPE = 'module-not-found';
+
+function cleanStackTrace (message) {
+  return message
+    .replace(/^\sat\s.*:\d+:\d+[\s\)]*\n/gm, ''); // at ... ...:x:y
+}
+
+function isModuleNotFoundError(e) {
+  const webpackError = e.webpackError;
+  return e.type === TYPE ||
+    e.name === 'ModuleNotFoundError' &&
+    e.message.indexOf('Module not found') === 0 &&
+    webpackError.dependencies && webpackError.dependencies.length;
+}
+
+function formatErrors(errors) {
+  const displayError = [];
+  displayError.push('These dependencies were not found in node_modules:');
+  displayError.push('');
+  errors.forEach((error, index) => displayError.push(`* ${error.module}`));
+  displayError.push('');
+  displayError.push('Did you forget to run npm install --save for them?')
+  return displayError;
+}
+
+module.exports = {
+  format: (errors) => {
+    const filteredErrors = errors.filter(isModuleNotFoundError);
+    return filteredErrors.length > 0 && formatErrors(filteredErrors);
+  },
+  transform: (error) => {
+    const webpackError = error.webpackError;
+    if (isModuleNotFoundError(error)) {
+      return Object.assign({}, error, {
+        message: `Module not found ${webpackError.dependencies[0].request}`,
+        module: webpackError.dependencies[0].request,
+        type: TYPE,
+        severity: 900,
+      });
+    }
+
+    return error;
+  },
+};

--- a/src/transformers/moduleNotFound.js
+++ b/src/transformers/moduleNotFound.js
@@ -1,10 +1,5 @@
 const TYPE = 'module-not-found';
 
-function cleanStackTrace (message) {
-  return message
-    .replace(/^\sat\s.*:\d+:\d+[\s\)]*\n/gm, ''); // at ... ...:x:y
-}
-
 function isModuleNotFoundError(e) {
   const webpackError = e.webpackError;
   return e.type === TYPE ||
@@ -13,32 +8,18 @@ function isModuleNotFoundError(e) {
     webpackError.dependencies && webpackError.dependencies.length;
 }
 
-function formatErrors(errors) {
-  const displayError = [];
-  displayError.push('These dependencies were not found in node_modules:');
-  displayError.push('');
-  errors.forEach((error, index) => displayError.push(`* ${error.module}`));
-  displayError.push('');
-  displayError.push('Did you forget to run npm install --save for them?')
-  return displayError;
+function transform(error) {
+  const webpackError = error.webpackError;
+  if (isModuleNotFoundError(error)) {
+    return Object.assign({}, error, {
+      message: `Module not found ${webpackError.dependencies[0].request}`,
+      module: webpackError.dependencies[0].request,
+      type: TYPE,
+      severity: 900,
+    });
+  }
+
+  return error;
 }
 
-module.exports = {
-  format: (errors) => {
-    const filteredErrors = errors.filter(isModuleNotFoundError);
-    return filteredErrors.length > 0 && formatErrors(filteredErrors);
-  },
-  transform: (error) => {
-    const webpackError = error.webpackError;
-    if (isModuleNotFoundError(error)) {
-      return Object.assign({}, error, {
-        message: `Module not found ${webpackError.dependencies[0].request}`,
-        module: webpackError.dependencies[0].request,
-        type: TYPE,
-        severity: 900,
-      });
-    }
-
-    return error;
-  },
-};
+module.exports = transform;

--- a/src/transformers/moduleNotFound.js
+++ b/src/transformers/moduleNotFound.js
@@ -1,21 +1,22 @@
 const TYPE = 'module-not-found';
 
 function isModuleNotFoundError(e) {
-  const webpackError = e.webpackError;
-  return e.type === TYPE ||
-    e.name === 'ModuleNotFoundError' &&
-    e.message.indexOf('Module not found') === 0 &&
-    webpackError.dependencies && webpackError.dependencies.length;
+  const { webpackError = {} } = e;
+  return webpackError.dependencies && webpackError.dependencies.length &&
+    (e.type === TYPE ||
+     e.name === 'ModuleNotFoundError' &&
+     e.message.indexOf('Module not found') === 0);
 }
 
 function transform(error) {
   const webpackError = error.webpackError;
   if (isModuleNotFoundError(error)) {
+    const module = webpackError.dependencies[0].request;
     return Object.assign({}, error, {
-      message: `Module not found ${webpackError.dependencies[0].request}`,
-      module: webpackError.dependencies[0].request,
+      message: `Module not found ${module}`,
       type: TYPE,
       severity: 900,
+      module,
     });
   }
 

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -33,8 +33,8 @@ test('integration : babel syntax error', t => {
     '',
     '1) Error in ./fixtures/babel-syntax/index.js',
     '',
-    `Module build failed: SyntaxError: /Users/geowarin/dev/projects/friendly-errors-webpack-plugin/test/fixtures/babel-syntax/index.js: Unexpected token (5:11)
-  3 |
+    `Module build failed: SyntaxError: ${__dirname}/fixtures/babel-syntax/index.js: Unexpected token (5:11)
+  3 |${' '}
   4 |   render() {
 > 5 |     return <div>
     |            ^

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -34,7 +34,7 @@ test('integration : babel syntax error', t => {
     '1) Error in ./fixtures/babel-syntax/index.js',
     '',
     `Module build failed: SyntaxError: /Users/geowarin/dev/projects/friendly-errors-webpack-plugin/test/fixtures/babel-syntax/index.js: Unexpected token (5:11)
-  3 | 
+  3 |
   4 |   render() {
 > 5 |     return <div>
     |            ^

--- a/test/unit/formatErrors.spec.js
+++ b/test/unit/formatErrors.spec.js
@@ -1,0 +1,28 @@
+const formatErrors = require('../../src/formatErrors');
+const expect = require('expect');
+const test = require('ava');
+
+const simple = (errors) => errors
+  .filter(({ type }) => !type).map(({ message }) => message);
+
+const allCaps = (errors) => errors
+  .filter(({ type }) => type == 'other').map((e) => e.message.toUpperCase());
+
+const notFound = (errors) => errors
+  .filter(({ type }) => type === 'not-found').map(() => 'Not found');
+
+const formatters = [allCaps]
+
+test('formats the error based on the matching formatters', () => {
+  const errors = [
+    { message: 'Error 1', type: undefined },
+    { message: 'Error 2', type: 'other' },
+    { message: 'Error 3', type: 'not-found' },
+  ];
+
+  expect(formatErrors(errors, [simple, allCaps, notFound], 'Error')).toEqual([
+    'Error 1',
+    'ERROR 2',
+    'Not found',
+  ]);
+});

--- a/test/unit/formatters/defaultError.spec.js
+++ b/test/unit/formatters/defaultError.spec.js
@@ -1,0 +1,31 @@
+const defaultError = require('../../../src/formatters/defaultError');
+const expect = require('expect');
+const test = require('ava');
+const chalk = require('chalk');
+
+const noColor = (arr) => arr.map(chalk.stripColor)
+const error = { message: 'Error message', file: './src/index.js' };
+
+test('Formats errors with no type', () => {
+  expect(noColor(defaultError([error], 'Warning'))).toEqual([
+    '1) Warning in ./src/index.js',
+    '',
+    'Error message',
+    '',
+  ]);
+});
+
+test('Formats babel-syntax-errors', () => {
+  const babeError = { ...error, type: 'babel-syntax-error' };
+  expect(noColor(defaultError([babeError], 'Error'))).toEqual([
+    '1) Error in ./src/index.js',
+    '',
+    'Error message',
+    '',
+  ]);
+});
+
+test('Does not format other errors', () => {
+  const otherError = { ...error, type: 'other-error' };
+  expect(noColor(defaultError([otherError], 'Error'))).toEqual([]);
+});

--- a/test/unit/formatters/moduleNotFound.spec.js
+++ b/test/unit/formatters/moduleNotFound.spec.js
@@ -1,0 +1,32 @@
+const moduleNotFound = require('../../../src/formatters/moduleNotFound');
+const expect = require('expect');
+const test = require('ava');
+
+test('Formats module-not-found errors', () => {
+  const error = { type: 'module-not-found', module: 'redux' };
+  expect(moduleNotFound([error])).toEqual([
+    'This dependency was not found in node_modules:',
+    '',
+    '* redux',
+    '',
+    'Did you forget to run npm install --save for it?'
+  ]);
+});
+
+test('Groups all module-not-found into one', () => {
+  const reduxError = { type: 'module-not-found', module: 'redux' };
+  const reactError = { type: 'module-not-found', module: 'react' };
+  expect(moduleNotFound([reduxError, reactError])).toEqual([
+    'These dependencies were not found in node_modules:',
+    '',
+    '* redux',
+    '* react',
+    '',
+    'Did you forget to run npm install --save for them?'
+  ]);
+});
+
+test('Does not format other errors', () => {
+  const otherError = { type: 'other-error', module: 'foo' };
+  expect(moduleNotFound([otherError])).toEqual([]);
+});

--- a/test/unit/transformers/babelSyntax.spec.js
+++ b/test/unit/transformers/babelSyntax.spec.js
@@ -1,0 +1,19 @@
+const babelSyntax = require('../../../src/transformers/babelSyntax');
+const expect = require('expect');
+const test = require('ava');
+
+
+test('Sets severity to 1000', () => {
+  const error = { type: 'babel-syntax-error' };
+  expect(babelSyntax(error).severity).toEqual(1000);
+});
+
+test('Sets type to babel-syntax-error', () => {
+  const error = { name: 'ModuleBuildError', message: 'SyntaxError' };
+  expect(babelSyntax(error).type).toEqual('babel-syntax-error');
+});
+
+test('Ignores other errors', () => {
+  const error = { name: 'OtherError' };
+  expect(babelSyntax(error)).toEqual(error);
+});

--- a/test/unit/transformers/moduleNotFound.spec.js
+++ b/test/unit/transformers/moduleNotFound.spec.js
@@ -1,0 +1,42 @@
+const moduleNotFound = require('../../../src/transformers/moduleNotFound');
+const expect = require('expect');
+const test = require('ava');
+
+const error = {
+  type: 'module-not-found',
+  webpackError: {
+    dependencies: [{ request: 'redux' } ],
+  },
+};
+
+test('Sets severity to 900', () => {
+  expect(moduleNotFound(error).severity).toEqual(900);
+});
+
+test('Sets module name', () => {
+  expect(moduleNotFound(error).module).toEqual('redux');
+});
+
+test('Sets the appropiate message', () => {
+  const message = 'Module not found redux';
+  expect(moduleNotFound(error).message).toEqual(message);
+});
+
+test('Sets the appropiate message', () => {
+  const message = 'Module not found redux';
+  expect(moduleNotFound({
+    name: 'ModuleNotFoundError',
+    message: 'Module not found',
+    webpackError: error.webpackError,
+  }).type).toEqual('module-not-found');
+});
+
+// test('Sets type to babel-syntax-error', () => {
+//   const error = { name: 'ModuleBuildError', message: 'SyntaxError' };
+//   expect(moduleNotFound(error).type).toEqual('babel-syntax-error');
+// });
+//
+// test('Ignores other errors', () => {
+//   const error = { name: 'OtherError' };
+//   expect(moduleNotFound(error)).toEqual(error);
+// });

--- a/test/unit/transformers/moduleNotFound.spec.js
+++ b/test/unit/transformers/moduleNotFound.spec.js
@@ -31,12 +31,7 @@ test('Sets the appropiate message', () => {
   }).type).toEqual('module-not-found');
 });
 
-// test('Sets type to babel-syntax-error', () => {
-//   const error = { name: 'ModuleBuildError', message: 'SyntaxError' };
-//   expect(moduleNotFound(error).type).toEqual('babel-syntax-error');
-// });
-//
-// test('Ignores other errors', () => {
-//   const error = { name: 'OtherError' };
-//   expect(moduleNotFound(error)).toEqual(error);
-// });
+test('Ignores other errors', () => {
+  const error = { name: 'OtherError' };
+  expect(moduleNotFound(error)).toEqual(error);
+});


### PR DESCRIPTION
More context here: https://github.com/facebookincubator/create-react-app/issues/401

Given that you created this repo I decided that it would make more sense to make a PR here rather than in the create-react-app repo.

This is a really early implementation of my proposal, please feel more than free to tell me if this is totally wrong :) There is still a lot of clean up that I need to do and add tests to all of it.

It would be great if we could make the core of this plugin agnostic of what the which types of errors it knows how to parse. In my proposal the plugin only knows that it has a set of transformers and a set of formatters. We could modify it so that the user could inject extra transformers and formatters in their Webpack config `new FriendlyErrorsWebpackPlugin({ extraTransformers: [...], extraFormatters: [...])`. 

There are two concepts that I've added.  I'm still not super happy the names or the exact responsibilities of each of them, but I think that something like it could be interesting.
* **Transformers**: (error) => (error)... Given an error it will transform it the "next" error state or add some type of metadata if it matches certain criteria. For example the `moduleNotFound` transformer will add the appropriate type and specific module name to the error.
* **Formatters**: ([error]) => ([logStatements or chunks])... Given a collection of errors it will return a collection of log statements to print of for those set of errors. For example the `moduleNotFound` formatter will gather and group all the missing modules.

Again, this is still an early implementation and I'm not super happy with parts of it, but this will also allow us easily unit test each of the transformers and formatter

Imagine if we could make it really easy to add any set of error formatters. That will mean that the community can build formatters for any specific use case, if someone already knows JavaScript but it is their first time exposed to ES6 they could add a something like a `es6HelpFormatter` that whenever errors like this `TypeError: Assignment to constant variable.` show up, it will also give them a detail explanation of what `const` is, along with a link to a blog post or to MDN.