### PR TITLE
Fix default value of the clearConsole option

### DIFF
--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -28,7 +28,7 @@ class FriendlyErrorsWebpackPlugin {
     options = options || {};
     this.compilationSuccessInfo = options.compilationSuccessInfo || {};
     this.onErrors = options.onErrors;
-    this.shouldClearConsole = Boolean(options.clearConsole);
+    this.shouldClearConsole = options.clearConsole == null ? true : Boolean(options.clearConsole);
     this.formatters = concat(defaultFormatters, options.additionalFormatters);
     this.transformers = concat(defaultTransformers, options.additionalTransformers);
   }

--- a/test/unit/plugin/friendlyErrors.spec.js
+++ b/test/unit/plugin/friendlyErrors.spec.js
@@ -39,6 +39,16 @@ test('friendlyErrors : capture compilation without errors', t => {
   ]);
 });
 
+test('friendlyErrors : default clearConsole option', t => {
+  const plugin = new FriendlyErrorsPlugin();
+  assert.strictEqual(plugin.shouldClearConsole, true)
+});
+
+test('friendlyErrors : clearConsole option', t => {
+  const plugin = new FriendlyErrorsPlugin({ clearConsole: false });
+  assert.strictEqual(plugin.shouldClearConsole, false)
+});
+
 function successfulCompilationStats() {
   const compilation = {
     errors: [],


### PR DESCRIPTION
It looks https://github.com/geowarin/friendly-errors-webpack-plugin/pull/10 caused to set wrong default value for the option.