### PR TITLE
Fix win ci

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -75,7 +75,7 @@ class Debugger {
 
   captureConsole (args, method) {
     if (this.capturing) {
-      this.capturedMessages.push(chalk.stripColor(args.join(' ').trim()));
+      this.capturedMessages.push(chalk.stripColor(args.join(' ')).trim());
     } else {
       method.apply(console, args);
     }

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -11,7 +11,11 @@ function cleanStackTrace(message) {
 
 function cleanMessage(message) {
   return message
-    .replace('Module build failed: ', '');
+  // match until the last semicolon followed by a space
+  // this should match
+  // linux => "(SyntaxError: )Unexpected token (5:11)"
+  // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
+    .replace(/^Module build failed.*:\s/, 'Syntax Error: ');
 }
 
 function isBabelSyntaxError(e) {

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -84,7 +84,7 @@ it('integration : babel syntax error', async () => {
     '',
     'error  in ./test/fixtures/babel-syntax/index.js',
     '',
-    `SyntaxError: Unexpected token (5:11)
+    `Syntax Error: Unexpected token (5:11)
 
   3 |${' '}
   4 |   render() {

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -44,7 +44,7 @@ it('integration : module-errors', async () => {
   const logs = await executeAndGetLogs('./fixtures/module-errors/webpack.config.js');
 
   expect(logs).toEqual([
-    ' ERROR  Failed to compile with 2 errors',
+    'ERROR  Failed to compile with 2 errors',
     '',
     'These dependencies were not found in node_modules:',
     '',
@@ -60,15 +60,14 @@ it('integration : should display eslint warnings', async () => {
   const logs = await executeAndGetLogs('./fixtures/eslint-warnings/webpack.config.js');
 
   expect(logs).toEqual([
-    ' WARNING  Compiled with 1 warnings',
+    'WARNING  Compiled with 1 warnings',
     '',
-    ' warning  in ./test/fixtures/eslint-warnings/index.js',
+    'warning  in ./test/fixtures/eslint-warnings/index.js',
     '',
     `${__dirname}/fixtures/eslint-warnings/index.js
   1:7  warning  'unused' is assigned a value but never used  no-unused-vars
 
-✖ 1 problem (0 errors, 1 warning)
-`,
+✖ 1 problem (0 errors, 1 warning)`,
     '',
     'You may use special comments to disable some warnings.',
     'Use // eslint-disable-next-line to ignore the next line.',
@@ -81,9 +80,9 @@ it('integration : babel syntax error', async () => {
   const logs = await executeAndGetLogs('./fixtures/babel-syntax/webpack.config');
 
   expect(logs).toEqual([
-    ' ERROR  Failed to compile with 1 errors',
+    'ERROR  Failed to compile with 1 errors',
     '',
-    ' error  in ./test/fixtures/babel-syntax/index.js',
+    'error  in ./test/fixtures/babel-syntax/index.js',
     '',
     `SyntaxError: Unexpected token (5:11)
 
@@ -113,7 +112,7 @@ it('integration : webpack multi compiler : module-errors', async () => {
   const logs = await executeAndGetLogs('./fixtures/multi-compiler-module-errors/webpack.config', globalPlugins);
 
   expect(logs).toEqual([
-    ' ERROR  Failed to compile with 2 errors',
+    'ERROR  Failed to compile with 2 errors',
     '',
     'These dependencies were not found in node_modules:',
     '',

--- a/test/unit/plugin/friendlyErrors.spec.js
+++ b/test/unit/plugin/friendlyErrors.spec.js
@@ -18,7 +18,7 @@ it('friendlyErrors : capture invalid message', () => {
   });
 
   expect(logs).toEqual([
-    ' WAIT  Compiling...',
+    'WAIT  Compiling...',
     ''
     ]);
 });
@@ -31,7 +31,7 @@ it('friendlyErrors : capture compilation without errors', () => {
   });
 
   expect(logs).toEqual([
-    ' DONE  Compiled successfully in 100ms',
+    'DONE  Compiled successfully in 100ms',
     ''
   ]);
 });


### PR DESCRIPTION
When setting up appveyor, I noticed the path of the file was repeated on windows when a babel syntax error was found.
This is probably a babel-loader bug but I decided to go ahead and fix it.

There is another error with the eslint loader where the path is also repeated.
I think we can do a better work cleaning eslint errors (#15) so I let this one fail for the moment.