### PR TITLE
Improve eslint messages

### DIFF
--- a/src/formatters/eslintError.js
+++ b/src/formatters/eslintError.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const concat = require('../utils').concat;
+const chalk = require('chalk');
+
+const infos = [
+  'You may use special comments to disable some warnings.',
+  'Use ' + chalk.yellow('// eslint-disable-next-line') + ' to ignore the next line.',
+  'Use ' + chalk.yellow('/* eslint-disable */') + ' to ignore all warnings in a file.'
+];
+
+function displayError(error) {
+  return [error.message, '']
+}
+
+function format(errors, type) {
+  const lintErrors = errors.filter(e => e.type === 'lint-error');
+  if (lintErrors.length > 0) {
+    const flatten = (accum, curr) => accum.concat(curr);
+    return concat(
+      lintErrors
+        .map(error => displayError(error))
+        .reduce(flatten, []),
+      infos
+    )
+  }
+
+  return [];
+}
+
+module.exports = format;

--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -19,6 +19,7 @@ const defaultTransformers = [
 
 const defaultFormatters = [
   require('./formatters/moduleNotFound'),
+  require('./formatters/eslintError'),
   require('./formatters/defaultError'),
 ];
 

--- a/src/transformers/esLintError.js
+++ b/src/transformers/esLintError.js
@@ -10,12 +10,8 @@ function isEslintError (e) {
 function transform(error) {
   if (isEslintError(error)) {
     return Object.assign({}, error, {
-      infos: [
-        'You may use special comments to disable some warnings.',
-        'Use ' + chalk.yellow('// eslint-disable-next-line') + ' to ignore the next line.',
-        'Use ' + chalk.yellow('/* eslint-disable */') + ' to ignore all warnings in a file.'
-      ],
       name: 'Lint error',
+      type: 'lint-error',
     });
   }
 

--- a/test/fixtures/eslint-warnings/index.js
+++ b/test/fixtures/eslint-warnings/index.js
@@ -1,1 +1,4 @@
+require('./module');
+
 const unused = 'I am unused';
+const unused2 = 'I am unused too';

--- a/test/fixtures/eslint-warnings/module.js
+++ b/test/fixtures/eslint-warnings/module.js
@@ -1,0 +1,1 @@
+const unused = 'I am unused';

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -4,8 +4,9 @@ const output = require('../src/output');
 const webpack = require('webpack');
 const FriendlyErrorsWebpackPlugin = require('../src/friendly-errors-plugin');
 const MemoryFileSystem = require('memory-fs');
+const path = require('path');
 
-const webpackPromise = function(config, globalPlugins) {
+const webpackPromise = function (config, globalPlugins) {
   const compiler = webpack(config);
   compiler.outputFileSystem = new MemoryFileSystem();
   if (Array.isArray(globalPlugins)) {
@@ -32,14 +33,14 @@ async function executeAndGetLogs(fixture, globalPlugins) {
   }
 }
 
-it('integration : success', async () => {
+it('integration : success', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/success/webpack.config')
 
   expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/);
 });
 
-it('integration : module-errors', async () => {
+it('integration : module-errors', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/module-errors/webpack.config.js');
 
@@ -55,27 +56,35 @@ it('integration : module-errors', async () => {
   ]);
 });
 
-it('integration : should display eslint warnings', async () => {
+function filename(filePath) {
+  return path.join(__dirname, path.normalize(filePath))
+}
+
+it.only('integration : should display eslint warnings', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/eslint-warnings/webpack.config.js');
 
-  expect(logs).toEqual([
-    'WARNING  Compiled with 1 warnings',
-    '',
-    'warning  in ./test/fixtures/eslint-warnings/index.js',
-    '',
-    `${__dirname}/fixtures/eslint-warnings/index.js
+  expect(logs.join('\n')).toEqual(
+    `WARNING  Compiled with 2 warnings
+
+${filename('fixtures/eslint-warnings/index.js')}
+  3:7  warning  'unused' is assigned a value but never used   no-unused-vars
+  4:7  warning  'unused2' is assigned a value but never used  no-unused-vars
+
+✖ 2 problems (0 errors, 2 warnings)
+
+${filename('fixtures/eslint-warnings/module.js')}
   1:7  warning  'unused' is assigned a value but never used  no-unused-vars
 
-✖ 1 problem (0 errors, 1 warning)`,
-    '',
-    'You may use special comments to disable some warnings.',
-    'Use // eslint-disable-next-line to ignore the next line.',
-    'Use /* eslint-disable */ to ignore all warnings in a file.'
-  ]);
+✖ 1 problem (0 errors, 1 warning)
+
+You may use special comments to disable some warnings.
+Use // eslint-disable-next-line to ignore the next line.
+Use /* eslint-disable */ to ignore all warnings in a file.`
+  )
 });
 
-it('integration : babel syntax error', async () => {
+it('integration : babel syntax error', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/babel-syntax/webpack.config');
 
@@ -96,7 +105,7 @@ it('integration : babel syntax error', async () => {
   ]);
 });
 
-it('integration : webpack multi compiler : success', async () => {
+it('integration : webpack multi compiler : success', async() => {
 
   // We apply the plugin directly to the compiler when targeting multi-compiler
   let globalPlugins = [new FriendlyErrorsWebpackPlugin()];
@@ -105,7 +114,7 @@ it('integration : webpack multi compiler : success', async () => {
   expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/)
 });
 
-it('integration : webpack multi compiler : module-errors', async () => {
+it('integration : webpack multi compiler : module-errors', async() => {
 
   // We apply the plugin directly to the compiler when targeting multi-compiler
   let globalPlugins = [new FriendlyErrorsWebpackPlugin()];


### PR DESCRIPTION
Fix #15

Es-lint warnings should now be grouped correctly (showing the hints once) and not show the stacktrace of the eslint loader nor duplicated file information