### PR TITLE
Fix issues giving a SyntaxError.

### DIFF
--- a/src/formatters/moduleNotFound.js
+++ b/src/formatters/moduleNotFound.js
@@ -35,7 +35,7 @@ function dependenciesNotFound (dependencies) {
     '',
     dependencies.map(formatGroup),
     '',
-    forgetToInstall(dependencies),
+    forgetToInstall(dependencies)
   );
 }
 
@@ -45,7 +45,7 @@ function relativeModulesNotFound (modules) {
   return concat(
     modules.length === 1 ? 'This relative module was not found:' : 'These relative modules were not found:',
     '',
-    modules.map(formatGroup),
+    modules.map(formatGroup)
   );
 }
 
@@ -79,7 +79,7 @@ function formatErrors (errors) {
   return concat(
     dependenciesNotFound(dependencies),
     dependencies.length && relativeModules.length ? ['', ''] : null,
-    relativeModulesNotFound(relativeModules),
+    relativeModulesNotFound(relativeModules)
   );
 }
 


### PR DESCRIPTION
I got three `SyntaxError: Unexpected token )` errors in `formatters/moduleNotFound.js`, these were caused by an additional comma at the end of the statement.