### PR TITLE
Add `Last compile` and `Took` to the output

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -51,7 +51,7 @@ class Debugger {
   title (severity, title, subtitle) {
     if (this.enabled) {
       const date = new Date();
-      const dateString = chalk.grey(date.toLocaleTimeString());
+      const dateString = chalk.blue(date.toLocaleTimeString());
       const titleFormatted = colors.formatTitle(severity, title);
       const subTitleFormatted = colors.formatText(severity, subtitle);
       const message = `${titleFormatted} ${subTitleFormatted}`


### PR DESCRIPTION
Hi @geowarin,

I added an option for dateString, took, displayLastCompile and displayTook:
```javascript
const defaultOutputOptions = {
  dateString: {
    color: 'blue',
  },
  took: {
    // can be "ms" or "s"
    on: 'ms',
    // greater than 5000 ms, it will be displayed on red
    // (!) if took.on === 's' then took.red must be on seconds too
    red: 5000,
  },
  displayLastCompile: true,
  displayTook: true,
};
```
