### PR TITLE
Use recommended way to turn off webpack-hot-middleware errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ If you use the webpack-dev-server, there is a setting in webpack's ```devServer`
 }
 ```
 
-If you use webpack-hot-middleware, that is done by setting the log option to a no-op. You can do something sort of like this, depending upon your setup:
+If you use webpack-hot-middleware, that is done by setting the log option to `false`. You can do something sort of like this, depending upon your setup:
 
 ```javascript
 app.use(require('webpack-hot-middleware')(compiler, {
-  log: () => {}
+  log: false
 }));
 ```
 


### PR DESCRIPTION
For disabling logs for `hotMiddleware`, we need not pass a `noop`, we can use `false`.

Relevant docs - [glenjamin/webpack-hot-middleware#middleware](https://github.com/glenjamin/webpack-hot-middleware#middleware)

Please let me know if I am missing something and there is any significance to using the no-op