### PR TITLE
Remove webpack 4 warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.23.1",

--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -36,7 +36,7 @@ class FriendlyErrorsWebpackPlugin {
 
   apply(compiler) {
 
-    compiler.plugin('done', stats => {
+    const doneFn = stats => {
       this.clearConsole();
 
       const hasErrors = stats.hasErrors();
@@ -55,12 +55,22 @@ class FriendlyErrorsWebpackPlugin {
       if (hasWarnings) {
         this.displayErrors(extractErrorsFromStats(stats, 'warnings'), 'warning');
       }
-    });
+    };
 
-    compiler.plugin('invalid', () => {
+    const invalidFn = () => {
       this.clearConsole();
       output.title('info', 'WAIT', 'Compiling...');
-    });
+    };
+
+    if (compiler.hooks) {
+      const plugin = { name: 'FriendlyErrorsWebpackPlugin' };
+
+      compiler.hooks.done.tap(plugin, doneFn);
+      compiler.hooks.invalid.tap(plugin, invalidFn);
+    } else {
+      compiler.plugin('done', doneFn);
+      compiler.plugin('invalid', invalidFn);
+    }
   }
 
   clearConsole() {

--- a/src/transformers/moduleNotFound.js
+++ b/src/transformers/moduleNotFound.js
@@ -3,7 +3,7 @@
 const TYPE = 'module-not-found';
 
 function isModuleNotFoundError (e) {
-  const webpackError = e.webpackError || {};
+  const webpackError = e.webpackError || {};
   return webpackError.dependencies
     && webpackError.dependencies.length > 0
     && e.name === 'ModuleNotFoundError'

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -10,7 +10,7 @@ const webpackPromise = function (config, globalPlugins) {
   const compiler = webpack(config);
   compiler.outputFileSystem = new MemoryFileSystem();
   if (Array.isArray(globalPlugins)) {
-    globalPlugins.forEach(p => compiler.apply(p));
+    globalPlugins.forEach(p => p.apply(compiler));
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
In webpack 4, `Tapable#apply` and `Tapable#plugin` raise a **deprecation notice**.

- `Tapable#apply(plugin)` must be replaced by a call to `plugin.apply`
- `Tapable#plugin(hook, fn)` must be replaced by a call to `hook.tap` (or `hook.tapAsync`)

Fix #62 
