### PR TITLE
Updated to report correct time in multicompiler watch mode

### DIFF
--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -32,6 +32,7 @@ class FriendlyErrorsWebpackPlugin {
     this.shouldClearConsole = options.clearConsole == null ? true : Boolean(options.clearConsole);
     this.formatters = concat(defaultFormatters, options.additionalFormatters);
     this.transformers = concat(defaultTransformers, options.additionalTransformers);
+    this.previousEndTimes = {};
   }
 
   apply(compiler) {
@@ -80,7 +81,7 @@ class FriendlyErrorsWebpackPlugin {
   }
 
   displaySuccess(stats) {
-    const time = getCompileTime(stats);
+    const time = this.getCompileTime(stats);
     output.title('success', 'DONE', 'Compiled successfully in ' + time + 'ms');
 
     if (this.compilationSuccessInfo.messages) {
@@ -110,6 +111,27 @@ class FriendlyErrorsWebpackPlugin {
     formatErrors(topErrors, this.formatters, severity)
       .forEach(chunk => output.log(chunk));
   }
+
+  getCompileTime(stats, statsIndex) {
+    if (isMultiStats(stats)) {
+      // Webpack multi compilations run in parallel so using the longest duration.
+      // https://webpack.github.io/docs/configuration.html#multiple-configurations
+      return stats.stats
+        .reduce((time, stats, index) => Math.max(time, this.getCompileTime(stats, index)), 0);
+    }
+
+    // When we have multi compilations but only one of them is rebuilt, we need to skip the
+    // unchanged compilers to report the true rebuild time.
+    if (statsIndex !== undefined) {
+      if (this.previousEndTimes[statsIndex] === stats.endTime) {
+        return 0;
+      }
+
+      this.previousEndTimes[statsIndex] = stats.endTime;
+    }
+
+    return stats.endTime - stats.startTime;
+  }
 }
 
 function extractErrorsFromStats(stats, type) {
@@ -121,16 +143,6 @@ function extractErrorsFromStats(stats, type) {
     return uniqueBy(errors, error => error.message);
   }
   return stats.compilation[type];
-}
-
-function getCompileTime(stats) {
-  if (isMultiStats(stats)) {
-    // Webpack multi compilations run in parallel so using the longest duration.
-    // https://webpack.github.io/docs/configuration.html#multiple-configurations
-    return stats.stats
-      .reduce((time, stats) => Math.max(time, getCompileTime(stats)), 0);
-  }
-  return stats.endTime - stats.startTime;
 }
 
 function isMultiStats(stats) {

--- a/test/unit/plugin/friendlyErrors.spec.js
+++ b/test/unit/plugin/friendlyErrors.spec.js
@@ -1,15 +1,21 @@
 const expect = require('expect');
 const EventEmitter = require('events');
 const Stats = require('webpack/lib/Stats');
+const MultiStats = require('webpack/lib/MultiStats');
 const Module = require('webpack/lib/Module');
 EventEmitter.prototype.plugin = EventEmitter.prototype.on;
 
 const output = require("../../../src/output");
 const FriendlyErrorsPlugin = require("../../../index");
 
-const notifierPlugin = new FriendlyErrorsPlugin();
-const mockCompiler = new EventEmitter();
-notifierPlugin.apply(mockCompiler);
+var notifierPlugin;
+var mockCompiler;
+
+beforeEach(() => {
+  notifierPlugin = new FriendlyErrorsPlugin();
+  mockCompiler = new EventEmitter();
+  notifierPlugin.apply(mockCompiler);
+});
 
 it('friendlyErrors : capture invalid message', () => {
 
@@ -46,13 +52,56 @@ it('friendlyErrors : clearConsole option', () => {
   expect(plugin.shouldClearConsole).toBeFalsy()
 });
 
-function successfulCompilationStats() {
+
+describe('friendlyErrors : multicompiler', () => {
+  it('supplies the correct max compile time across multiple stats', () => {
+    const stats1 = successfulCompilationStats({ startTime: 0, endTime: 1000 });
+    const stats2 = successfulCompilationStats({ startTime: 2, endTime: 2002 });
+    const multistats = new MultiStats([stats1, stats2]);
+
+    const logs = output.captureLogs(() => {
+      mockCompiler.emit('done', multistats);
+    });
+
+    expect(logs).toEqual([
+      'DONE  Compiled successfully in 2000ms',
+      ''
+    ]);
+  });
+
+  it('supplies the correct recompile time with rebuild', () => {
+    // Test that rebuilds do not use the prior "max" value when recompiling just one stats object.
+    // This ensures the user does not get incorrect build times in watch mode.
+    const stats1 = successfulCompilationStats({ startTime: 0, endTime: 1000 });
+    const stats2 = successfulCompilationStats({ startTime: 0, endTime: 500 });
+    const stats2Rebuild = successfulCompilationStats({ startTime: 1020, endTime: 1050 });
+
+    const multistats = new MultiStats([stats1, stats2]);
+    const multistatsRecompile = new MultiStats([stats1, stats2Rebuild]);
+
+    const logs = output.captureLogs(() => {
+      mockCompiler.emit('done', multistats);
+      mockCompiler.emit('done', multistatsRecompile);
+    });
+
+    expect(logs).toEqual([
+      'DONE  Compiled successfully in 1000ms',
+      '',
+      'DONE  Compiled successfully in 30ms',
+      ''
+    ]);
+  });
+})
+
+function successfulCompilationStats(opts) {
+  const options = Object.assign({ startTime: 0, endTime: 100 }, opts);
+
   const compilation = {
     errors: [],
     warnings: []
   };
   const stats = new Stats(compilation);
-  stats.startTime = 0;
-  stats.endTime = 100;
+  stats.startTime = options.startTime;
+  stats.endTime = options.endTime;
   return stats;
 }


### PR DESCRIPTION
This PR fixes a bug when using the `friendly-errors-webpack-plugin` along with watch mode and multiple compiler configs. When a new stats object is emitted for just one of the compilers the plugin was reporting times for all objects even if just one recompiled. This often would lead to incorrect times reported when the other bundle times were more expensive.


## Example of the issue

Say we had a webpack config like the following:

```js
// webpack.config.js

module.exports = [
  { name: "server", /* ... */ },
  { name: "client", /* ... */ },
];
```

and apply the plugin to webpack with multistats via the Node API:

```js
const config = require("./webpack.config.js");

const compiler = webpack(config);
new FriendlyErrorsWebpackPlugin().apply(compiler);
```

### Before the fix

Build:

<img width="569" alt="screen shot 2018-07-17 at 1 57 23 pm" src="https://user-images.githubusercontent.com/1911028/42837029-d2600cfa-89ca-11e8-9374-fe339067deba.png">

Recompile (incorrect time as it's comparing against the large time of the other bundle): 

<img width="569" alt="screen shot 2018-07-17 at 1 57 23 pm" src="https://user-images.githubusercontent.com/1911028/42837029-d2600cfa-89ca-11e8-9374-fe339067deba.png">

### With the fix

Build:

<img width="569" alt="screen shot 2018-07-17 at 1 57 23 pm" src="https://user-images.githubusercontent.com/1911028/42837029-d2600cfa-89ca-11e8-9374-fe339067deba.png">


Recompile: 

<img width="570" alt="screen shot 2018-07-17 at 1 57 43 pm" src="https://user-images.githubusercontent.com/1911028/42837042-d9a11324-89ca-11e8-8074-50e3e3efdadd.png">

