### PR TITLE
webpack-dev-middleware options for 3.0 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ You need to turn off all error logging by setting your webpack config quiet opti
 
 ```javascript
 app.use(require('webpack-dev-middleware')(compiler, {
-  quiet: true,
-  publicPath: config.output.publicPath,
+  // ...
+  logLevel: 'silent',
+  // ...
 }));
 ```
 


### PR DESCRIPTION
The settings to silence outputs properly have changed in webpack-dev-middleware 3.

I suggest this amendment to the README file.