### PR TITLE
Extend displaySuccess to output compile time unit based on size

### DIFF
--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -82,7 +82,7 @@ class FriendlyErrorsWebpackPlugin {
   displaySuccess(stats) {
     const rawTime = getCompileTime(stats);
     const time = rawTime > 1000 ?
-      (rawTime / 1000).toFixed(2) + 's' :
+      (rawTime / 1000).toFixed(1) + 's' :
       rawTime + 'ms'
     output.title('success', 'DONE', 'Compiled successfully in ' + time);
 

--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -80,8 +80,11 @@ class FriendlyErrorsWebpackPlugin {
   }
 
   displaySuccess(stats) {
-    const time = getCompileTime(stats);
-    output.title('success', 'DONE', 'Compiled successfully in ' + time + 'ms');
+    const rawTime = getCompileTime(stats);
+    const time = rawTime > 1000 ?
+      (rawTime / 1000).toFixed(2) + 's' :
+      rawTime + 'ms'
+    output.title('success', 'DONE', 'Compiled successfully in ' + time);
 
     if (this.compilationSuccessInfo.messages) {
       this.compilationSuccessInfo.messages.forEach(message => output.info(message));

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -37,7 +37,7 @@ it('integration : success', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/success/webpack.config')
 
-  expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/);
+  expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)m?s/);
 });
 
 it('integration : module-errors', async() => {


### PR DESCRIPTION
This handles cases where compile time might be very long such as after the initial build and avoids outputting something silly like `Compiled successfully in 91244ms` in favor of `Compiled successfully in 91.2s`.