### PR TITLE
Continue fix + test for "Cannot read property 'startsWith' of undefined"

### DIFF
--- a/src/transformers/moduleNotFound.js
+++ b/src/transformers/moduleNotFound.js
@@ -13,7 +13,8 @@ function isModuleNotFoundError (e) {
 function transform(error) {
   const webpackError = error.webpackError;
   if (isModuleNotFoundError(error)) {
-    const module = webpackError.dependencies[0].request;
+    const dependency = webpackError.dependencies[0];
+    const module = dependency.request || dependency.options.request;
     return Object.assign({}, error, {
       message: `Module not found ${module}`,
       type: TYPE,

--- a/test/unit/transformers/moduleNotFound.spec.js
+++ b/test/unit/transformers/moduleNotFound.spec.js
@@ -1,5 +1,6 @@
 const moduleNotFound = require('../../../src/transformers/moduleNotFound');
 const expect = require('expect');
+const RequireContextDependency = require('webpack/lib/dependencies/RequireContextDependency');
 
 const error = {
   name: 'ModuleNotFoundError',
@@ -22,8 +23,7 @@ it('Sets the appropiate message', () => {
   expect(moduleNotFound(error).message).toEqual(message);
 });
 
-it('Sets the appropiate message', () => {
-  const message = 'Module not found redux';
+it('Sets the appropiate type', () => {
   expect(moduleNotFound({
     name: 'ModuleNotFoundError',
     message: 'Module not found',
@@ -34,4 +34,16 @@ it('Sets the appropiate message', () => {
 it('Ignores other errors', () => {
   const error = { name: 'OtherError' };
   expect(moduleNotFound(error)).toEqual(error);
+});
+
+it('Sets the correct message with a RequireContextDependency', () => {
+  const message = 'Module not found redux';
+
+  expect(moduleNotFound({
+      name: 'ModuleNotFoundError',
+      message: 'Module not found : redux',
+      webpackError: {
+        dependencies: [ new RequireContextDependency('redux') ],
+      },
+  }).message).toEqual(message);
 });


### PR DESCRIPTION
Fixes #79 & fixes #69 

This builds on top of #80 - using the fix from that commit (with credit to the original author) + adding a test, as requested by @christophehurpeau.

We've gotten a report on symfony/weback-encore#445 of this exact issue. We would love to have it fixed - the error is really hard to debug.

Cheers!