### PR TITLE
improvements for supporting SCSS that with mini-css-extract-plugin

### DIFF
--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -11,12 +11,12 @@ function cleanStackTrace(message) {
 
 function cleanMessage(message) {
   return message
-  // match until the last semicolon followed by a space
-  // this should match
-  // linux => "(SyntaxError: )Unexpected token (5:11)"
-  // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
-    .replace(/^Module build failed.*:\s/, 'Syntax Error: ')
-    .replace(/^ModuleBuildError.*:\s/, 'Syntax Error: ');
+    // match until the last semicolon followed by a space
+    // this should match
+    // linux => "(SyntaxError: )Unexpected token (5:11)"
+    // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
+    .replace(/^Module build failed.*:\s/, '')
+    .replace(/^ModuleBuildError.*:\s/, '');
 }
 
 function isBabelSyntaxError(e) {

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -11,12 +11,15 @@ function cleanStackTrace(message) {
 
 function cleanMessage(message) {
   return message
-  // match until the last semicolon followed by a space
-  // this should match
-  // linux => "(SyntaxError: )Unexpected token (5:11)"
-  // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
+    // match until the last semicolon followed by a space
+    // this should match
+    // linux => "(SyntaxError: )Unexpected token (5:11)"
+    // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
     .replace(/^Module build failed.*:\s/, 'Syntax Error: ')
-    .replace(/^ModuleBuildError.*:\s/, 'Syntax Error: ');
+    // remove mini-css-extract-plugin loader tracing errors
+    .replace(/^Syntax Error: ModuleBuildError:.*:\s/, '')
+    // remove babel extra wording
+    .replace('SyntaxError: ', '');
 }
 
 function isBabelSyntaxError(e) {

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -15,11 +15,12 @@ function cleanMessage(message) {
   // this should match
   // linux => "(SyntaxError: )Unexpected token (5:11)"
   // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
-    .replace(/^Module build failed.*:\s/, 'Syntax Error: ');
+    .replace(/^Module build failed.*:\s/, '')
+    .replace(/^ModuleBuildError.*:\s/, '');
 }
 
 function isBabelSyntaxError(e) {
-  return e.name === 'ModuleBuildError' &&
+  return e.name === 'ModuleBuildError' ||
     e.message.indexOf('SyntaxError') >= 0;
 }
 

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -15,12 +15,12 @@ function cleanMessage(message) {
   // this should match
   // linux => "(SyntaxError: )Unexpected token (5:11)"
   // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
-    .replace(/^Module build failed.*:\s/, '')
-    .replace(/^ModuleBuildError.*:\s/, '');
+    .replace(/^Module build failed.*:\s/, 'Syntax Error: ')
+    .replace(/^ModuleBuildError.*:\s/, 'Syntax Error: ');
 }
 
 function isBabelSyntaxError(e) {
-  return e.name === 'ModuleBuildError' ||
+  return e.name === 'ModuleBuildError' || e.name === 'ModuleBuildError' &&
     e.message.indexOf('SyntaxError') >= 0;
 }
 

--- a/src/transformers/babelSyntax.js
+++ b/src/transformers/babelSyntax.js
@@ -11,12 +11,12 @@ function cleanStackTrace(message) {
 
 function cleanMessage(message) {
   return message
-    // match until the last semicolon followed by a space
-    // this should match
-    // linux => "(SyntaxError: )Unexpected token (5:11)"
-    // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
-    .replace(/^Module build failed.*:\s/, '')
-    .replace(/^ModuleBuildError.*:\s/, '');
+  // match until the last semicolon followed by a space
+  // this should match
+  // linux => "(SyntaxError: )Unexpected token (5:11)"
+  // windows => "(SyntaxError: C:/projects/index.js: )Unexpected token (5:11)"
+    .replace(/^Module build failed.*:\s/, 'Syntax Error: ')
+    .replace(/^ModuleBuildError.*:\s/, 'Syntax Error: ');
 }
 
 function isBabelSyntaxError(e) {

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -33,14 +33,14 @@ async function executeAndGetLogs(fixture, globalPlugins) {
   }
 }
 
-it('integration : success', async () => {
+it('integration : success', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/success/webpack.config')
 
   expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/);
 });
 
-it('integration : module-errors', async () => {
+it('integration : module-errors', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/module-errors/webpack.config.js');
 
@@ -65,7 +65,7 @@ function filename(filePath) {
   return path.join(__dirname, path.normalize(filePath))
 }
 
-it('integration : should display eslint warnings', async () => {
+it('integration : should display eslint warnings', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/eslint-warnings/webpack.config.js');
 
@@ -89,7 +89,7 @@ Use /* eslint-disable */ to ignore all warnings in a file.`
   )
 });
 
-it('integration : babel syntax error', async () => {
+it('integration : babel syntax error', async() => {
 
   const logs = await executeAndGetLogs('./fixtures/babel-syntax/webpack.config');
 
@@ -98,7 +98,7 @@ it('integration : babel syntax error', async () => {
     '',
     'error  in ./test/fixtures/babel-syntax/index.js',
     '',
-    `Unexpected token (5:11)
+    `Syntax Error: Unexpected token (5:11)
 
   3 |${' '}
   4 |   render() {
@@ -110,7 +110,7 @@ it('integration : babel syntax error', async () => {
   ]);
 });
 
-it('integration : webpack multi compiler : success', async () => {
+it('integration : webpack multi compiler : success', async() => {
 
   // We apply the plugin directly to the compiler when targeting multi-compiler
   let globalPlugins = [new FriendlyErrorsWebpackPlugin()];
@@ -119,7 +119,7 @@ it('integration : webpack multi compiler : success', async () => {
   expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/)
 });
 
-it('integration : webpack multi compiler : module-errors', async () => {
+it('integration : webpack multi compiler : module-errors', async() => {
 
   // We apply the plugin directly to the compiler when targeting multi-compiler
   let globalPlugins = [new FriendlyErrorsWebpackPlugin()];

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -33,14 +33,14 @@ async function executeAndGetLogs(fixture, globalPlugins) {
   }
 }
 
-it('integration : success', async() => {
+it('integration : success', async () => {
 
   const logs = await executeAndGetLogs('./fixtures/success/webpack.config')
 
   expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/);
 });
 
-it('integration : module-errors', async() => {
+it('integration : module-errors', async () => {
 
   const logs = await executeAndGetLogs('./fixtures/module-errors/webpack.config.js');
 
@@ -65,7 +65,7 @@ function filename(filePath) {
   return path.join(__dirname, path.normalize(filePath))
 }
 
-it('integration : should display eslint warnings', async() => {
+it('integration : should display eslint warnings', async () => {
 
   const logs = await executeAndGetLogs('./fixtures/eslint-warnings/webpack.config.js');
 
@@ -89,7 +89,7 @@ Use /* eslint-disable */ to ignore all warnings in a file.`
   )
 });
 
-it('integration : babel syntax error', async() => {
+it('integration : babel syntax error', async () => {
 
   const logs = await executeAndGetLogs('./fixtures/babel-syntax/webpack.config');
 
@@ -98,7 +98,7 @@ it('integration : babel syntax error', async() => {
     '',
     'error  in ./test/fixtures/babel-syntax/index.js',
     '',
-    `Syntax Error: Unexpected token (5:11)
+    `Unexpected token (5:11)
 
   3 |${' '}
   4 |   render() {
@@ -110,7 +110,7 @@ it('integration : babel syntax error', async() => {
   ]);
 });
 
-it('integration : webpack multi compiler : success', async() => {
+it('integration : webpack multi compiler : success', async () => {
 
   // We apply the plugin directly to the compiler when targeting multi-compiler
   let globalPlugins = [new FriendlyErrorsWebpackPlugin()];
@@ -119,7 +119,7 @@ it('integration : webpack multi compiler : success', async() => {
   expect(logs.join('\n')).toMatch(/DONE  Compiled successfully in (.\d*)ms/)
 });
 
-it('integration : webpack multi compiler : module-errors', async() => {
+it('integration : webpack multi compiler : module-errors', async () => {
 
   // We apply the plugin directly to the compiler when targeting multi-compiler
   let globalPlugins = [new FriendlyErrorsWebpackPlugin()];


### PR DESCRIPTION
### Remove duplicate wording
![Screen Shot 2019-05-17 at 2 41 55 PM](https://user-images.githubusercontent.com/7368063/57949673-10eda680-78b3-11e9-9eec-5de0f75a501f.png)


### Make it working with SCSS that using `mini-css-extract-plugin`

#### Before
![Screen Shot 2019-05-17 at 1 01 02 PM](https://user-images.githubusercontent.com/7368063/57949725-35498300-78b3-11e9-8bf1-c0e5b56cd4a8.png)

#### After
![Screen Shot 2019-05-17 at 2 37 43 PM](https://user-images.githubusercontent.com/7368063/57949749-42ff0880-78b3-11e9-973b-f274c17ae5ca.png)

**with `implementation: require('sass')` option into sass-loader.**

![Screen Shot 2019-05-21 at 8 51 19 AM](https://user-images.githubusercontent.com/7368063/58097817-3a098200-7ba6-11e9-9d5b-34cd1f3f0cf3.png)


Please let me know if there is anything I don't realize because of changing the statement.