### PR TITLE
Make the message and note option support function in the compilationSuccessInfo option

### DIFF
--- a/src/friendly-errors-plugin.js
+++ b/src/friendly-errors-plugin.js
@@ -85,11 +85,15 @@ class FriendlyErrorsWebpackPlugin {
     output.title('success', 'DONE', 'Compiled successfully in ' + time + 'ms');
 
     if (this.compilationSuccessInfo.messages) {
-      this.compilationSuccessInfo.messages.forEach(message => output.info(message));
+      this.compilationSuccessInfo.messages.forEach(message => {
+        typeof message === 'function' ? output.info(message()) : output.info(message);
+      });
     }
     if (this.compilationSuccessInfo.notes) {
       output.log();
-      this.compilationSuccessInfo.notes.forEach(note => output.note(note));
+      this.compilationSuccessInfo.notes.forEach(note => {
+        typeof note === 'function' ? output.info(note()) : output.info(note);
+      });
     }
   }
 


### PR DESCRIPTION
I want the message to output the current time, and after every recompiled, so I need to pass in the function.
Just like this:
```javascript
new FriendlyErrorsPlugin({
  compilationSuccessInfo: {
    messages: [
      () => `${utils.getFormatDate()}Your application is running here: http://${webpackConfig.devServer.host}:${port}`
    ]
  }
});
```