### PR TITLE
Dropping support for Node 8, adding for Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
+  - 14
 
 cache:
   yarn: true


### PR DESCRIPTION
This bumps the test suite to supported Node versions.

Thanks!